### PR TITLE
fix(oauth): preserve headers on DPoP nonce retry

### DIFF
--- a/packages/atproto_oauth/client.py
+++ b/packages/atproto_oauth/client.py
@@ -407,6 +407,9 @@ class OAuthClient:
         if not is_safe_url(url):
             raise ValueError(f'Unsafe URL: {url}')
 
+        # Extract user headers once before the loop (preserve for DPoP nonce retry)
+        user_headers = kwargs.pop('headers', {})
+
         # Try request with retry for DPoP nonce
         for attempt in range(2):
             # Create DPoP proof
@@ -418,8 +421,8 @@ class OAuthClient:
                 access_token=session.access_token,
             )
 
-            # Add auth headers
-            headers = kwargs.pop('headers', {})
+            # Add auth headers to a copy of user headers
+            headers = user_headers.copy()
             headers['Authorization'] = f'DPoP {session.access_token}'
             headers['DPoP'] = dpop_proof
 


### PR DESCRIPTION
## Summary

Fixes a bug where user-provided headers (like `Content-Type`) were lost when the OAuth client retried a request due to a DPoP nonce error.

## Problem

The retry loop for DPoP nonce errors was calling `kwargs.pop('headers', {})` inside the loop:

```python
for attempt in range(2):
    headers = kwargs.pop('headers', {})  # BUG: loses headers on retry
    # ...
```

On the first attempt, headers would be popped and used correctly. But on retry (attempt 1), `kwargs` no longer contained `'headers'` since it was already popped, resulting in an empty headers dict.

This caused `uploadBlob` calls to fail with:
```
400 {"error":"InvalidRequest","message":"Request encoding (Content-Type) required but not provided"}
```

## Fix

Extract headers once before the loop, then copy them each iteration:

```python
user_headers = kwargs.pop('headers', {})  # Extract once
for attempt in range(2):
    headers = user_headers.copy()  # Copy each iteration
    # ...
```